### PR TITLE
Init as grid

### DIFF
--- a/Tests/unit/Test_dijsktra.gd
+++ b/Tests/unit/Test_dijsktra.gd
@@ -156,10 +156,12 @@ func test_create_as_grid():
 	var relative_connections := {}
 	var initial_offset := 0
 	map = DijkstraMap.new()
-	for size in 4:
-		gut.p("size : " +str(size))
-		gut.p("id to pos :")
-		gut.p(Tcreate_as_grid(map,relative_connections,initial_offset,size))
+	#UNCOMMENT IF YOU WANT TO SEE SOME DATA
+#	for size in 4:
+#		gut.p("size : " +str(size))
+#		gut.p("id to pos :")
+#		gut.p(Tcreate_as_grid(map,relative_connections,initial_offset,size))
+	#END UNCOMMENT
 	
 	map = DijkstraMap.new()
 	relative_connections = {Vector2.RIGHT : 1.0}
@@ -193,8 +195,8 @@ func Tcreate_as_grid(map,relatvConnect,initaloffset,size):
 	var bitmap := BitMap.new()
 	bitmap.create(Vector2.ONE * size)
 	bitmap.set_bit_rect(Rect2(Vector2.ZERO,\
-						Vector2.ONE * size)\
-						,true
+						Vector2.ONE * size),\
+						true
 					)
 	
 	

--- a/Tests/unit/Test_dijsktra.gd
+++ b/Tests/unit/Test_dijsktra.gd
@@ -153,5 +153,52 @@ func test_connect_point_bilateral():
 	assert_eq(map.get_cost_at_point(1),0.0)
 
 func test_create_as_grid():
-	pending("not decided in rust code")
+	var relative_connections := {}
+	var initial_offset := 0
+	map = DijkstraMap.new()
+	for size in 4:
+		gut.p("size : " +str(size))
+		gut.p("id to pos :")
+		gut.p(Tcreate_as_grid(map,relative_connections,initial_offset,size))
+	
+	map = DijkstraMap.new()
+	relative_connections = {Vector2.RIGHT : 1.0}
+	
+	var id_to_pos : Dictionary = Tcreate_as_grid(map,relative_connections,0,5)
+	## we get a way to pos -> id
+	var pos_to_id = {}
+	for each_id in id_to_pos.keys():
+		var each_pos = id_to_pos[each_id]
+		pos_to_id[each_pos] = each_id
+	##
+	var this_pos = Vector2(2,2)
+	
+	assert_true(\
+			map.has_connection(\
+						pos_to_id[this_pos],\
+						pos_to_id[this_pos + Vector2.RIGHT]\
+						),\
+			"a point not on the edge should be connected to its Right neighbour"
+				)
+	assert_false(\
+			map.has_connection(pos_to_id[this_pos + Vector2.RIGHT],\
+								pos_to_id[this_pos]\
+								),\
+			"but its not reciprocal"
+				)
+	
+	
+	
+func Tcreate_as_grid(map,relatvConnect,initaloffset,size):
+	var bitmap := BitMap.new()
+	bitmap.create(Vector2.ONE * size)
+	bitmap.set_bit_rect(Rect2(Vector2.ZERO,\
+						Vector2.ONE * size)\
+						,true
+					)
+	
+	
+	return map.initialize_as_grid(bitmap,relatvConnect,initaloffset)
+
+
 

--- a/project.godot
+++ b/project.godot
@@ -9,7 +9,7 @@
 config_version=4
 
 _global_script_classes=[ {
-"base": "Node",
+"base": "",
 "class": "DijkstraMap",
 "language": "NativeScript",
 "path": "res://dijkstra_map.gdns"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -741,7 +741,7 @@ impl DijkstraMap {
         let width = vec_size.x as i32;
         let height = vec_size.y as i32;
         let mut relative_connections: FnvHashMap<i32, f32> = FnvHashMap::default();
-        let mut id_to_pos : gdnative::Dictionary;
+        let mut id_to_pos : gdnative::Dictionary = gdnative::Dictionary::new();
         //extract relative connections to rust types.
         for dirs in relative_connections_in.keys().iter() {
             if let Some(vec2) = dirs.try_to_vector2() {
@@ -766,7 +766,7 @@ impl DijkstraMap {
                     grid.insert(id);
                     id_to_pos.set(
                         &gdnative::Variant::from_i64(id as i64),
-                        //TODO set the vector here but its type must be variant
+                        &gdnative::Variant::from_vector2(&pos)  //TODO set the vector here but its type must be variant
                     );
                 }
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -759,9 +759,15 @@ impl DijkstraMap {
         let mut grid = FnvHashSet::<i32>::default();
         for y in 0..height {
             for x in 0..width {
-                if bitmap.get_bit(gdnative::Vector2::new(x as f32, y as f32)) {
-                    self.add_point(_owner, x + y * width + initial_offset, 0);
-                    grid.insert(x + y * width + initial_offset);
+                let pos :gdnative::Vector2  = gdnative::Vector2::new(x as f32, y as f32);
+                if bitmap.get_bit(pos) {
+                    let id =  x + y * width + initial_offset;
+                    self.add_point(_owner,id, 0);
+                    grid.insert(id);
+                    id_to_pos.set(
+                        &gdnative::Variant::from_i64(id as i64),
+                        //TODO set the vector here but its type must be variant
+                    );
                 }
             }
         }
@@ -782,6 +788,7 @@ impl DijkstraMap {
                 }
             }
         }
+        return id_to_pos;
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -736,23 +736,23 @@ impl DijkstraMap {
         bitmap: gdnative::BitMap,
         relative_connections_in: gdnative::Dictionary,
         initial_offset: i32,
-    ) {
+    )-> gdnative::Dictionary {
         let vec_size = bitmap.get_size();
         let width = vec_size.x as i32;
         let height = vec_size.y as i32;
         let mut relative_connections: FnvHashMap<i32, f32> = FnvHashMap::default();
-
+        let mut id_to_pos : gdnative::Dictionary;
         //extract relative connections to rust types.
         for dirs in relative_connections_in.keys().iter() {
-            match dirs.try_to_vector2() {
-                None => continue,
-                Some(vec2) => {
+            if let Some(vec2) = dirs.try_to_vector2() {
                     let cost = relative_connections_in.get(dirs);
                     relative_connections.insert(
                         (vec2.x as i32) + (vec2.y as i32) * width,
                         cost.to_f64() as f32,
                     );
-                }
+            }
+            else {
+                continue;
             }
         }
 


### PR DESCRIPTION
okay I have a problem (im workin on it) for now I dont succeed in returning the dictionary from initialize_as_grid because when I try to set a key, the value must be a vector2 but must be recorded as a Variant and I dont know how to do that, I'm gonna look in the rust godot bindings to see if I find something