### PR TITLE
GitHub actions

### DIFF
--- a/.github/workflows/do_not_manually_update_binaries.yml
+++ b/.github/workflows/do_not_manually_update_binaries.yml
@@ -1,0 +1,31 @@
+name: Do not manually update the binaries
+
+on:
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  check_no_binary:
+    name: Do not include release binaries in a pull request
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 2
+      - shell: bash
+        id: check_binary_files_changed
+        env:
+          LINUX_BINARY: addons/dijkstra-map/Dijkstra_map_library/bin/linux/libdijkstra_map_gd.so
+          WINDOWS_BINARY: addons/dijkstra-map/Dijkstra_map_library/bin/windows/dijkstra_map_gd.dll
+          MACOS_BINARY: addons/dijkstra-map/Dijkstra_map_library/bin/macos/libdijkstra_map_gd.dylib
+        run: |
+          DIFF_LIST=$(git diff --name-only HEAD^ HEAD)
+          if [[ $DIFF_LIST == *$LINUX_BINARY* ]] || [[ $DIFF_LIST == *$WINDOWS_BINARY* ]] || [[ $DIFF_LIST == *$MACOS_BINARY* ]] ; then
+              FILE_CHANGED=True
+              exit 1
+          else
+              FILE_CHANGED=False
+              exit 0
+          fi

--- a/.github/workflows/make_release.yml
+++ b/.github/workflows/make_release.yml
@@ -17,7 +17,7 @@ env:
 
 jobs:
   build-linux:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     strategy:
       fail-fast: true

--- a/.github/workflows/make_release.yml
+++ b/.github/workflows/make_release.yml
@@ -6,10 +6,10 @@ on:
       - master
     inputs:
       version:
-        description: 'Version number'
+        description: "Version number"
         required: true
       body:
-        description: 'Description of the release'
+        description: "Description of the release"
         required: true
 
 env:
@@ -23,24 +23,24 @@ jobs:
       fail-fast: true
 
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions-rs/toolchain@v1
-      with:
-        toolchain: stable
-    - uses: Swatinem/rust-cache@v1
-    - uses: actions-rs/cargo@v1
-      with:
-        command: build
-        args: --release --verbose -p dijkstra_map_gd
-    - name: Strip library file
-      run: strip target/release/libdijkstra_map_gd.so
-    - uses: actions/upload-artifact@v2
-      with:
-        name: libdijkstra_map_gd.so
-        path: target/release/libdijkstra_map_gd.so
-  
-  # This jobs running on ubuntu-latest may be surprising : it's because I 
-  # couldn't make the build succeed on windows, but using the 
+      - uses: actions/checkout@v3
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+      - uses: Swatinem/rust-cache@v2
+      - uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --release --verbose -p dijkstra_map_gd
+      - name: Strip library file
+        run: strip target/release/libdijkstra_map_gd.so
+      - uses: actions/upload-artifact@v3
+        with:
+          name: libdijkstra_map_gd.so
+          path: target/release/libdijkstra_map_gd.so
+
+  # This jobs running on ubuntu-latest may be surprising : it's because I
+  # couldn't make the build succeed on windows, but using the
   # x86_64-pc-windows-gnu on linux works perfectly well.
   build-windows:
     runs-on: ubuntu-latest
@@ -49,24 +49,24 @@ jobs:
       fail-fast: true
 
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions-rs/toolchain@v1
-      with:
-        toolchain: stable
-        target: x86_64-pc-windows-gnu
-    - uses: Swatinem/rust-cache@v1
-    # we need a windows linker
-    - name: Install gcc-mingw-w64-x86-64 linker
-      run: sudo apt install gcc-mingw-w64-x86-64 
-    - uses: actions-rs/cargo@v1
-      with:
-        command: build
-        args: --release --verbose -p dijkstra_map_gd --target x86_64-pc-windows-gnu
-    - uses: actions/upload-artifact@v2
-      with:
-        name: dijkstra_map_gd.dll
-        path: target/x86_64-pc-windows-gnu/release/dijkstra_map_gd.dll
-  
+      - uses: actions/checkout@v3
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          target: x86_64-pc-windows-gnu
+      - uses: Swatinem/rust-cache@v2
+      # we need a windows linker
+      - name: Install gcc-mingw-w64-x86-64 linker
+        run: sudo apt install gcc-mingw-w64-x86-64
+      - uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --release --verbose -p dijkstra_map_gd --target x86_64-pc-windows-gnu
+      - uses: actions/upload-artifact@v3
+        with:
+          name: dijkstra_map_gd.dll
+          path: target/x86_64-pc-windows-gnu/release/dijkstra_map_gd.dll
+
   build-macos:
     runs-on: macos-latest
 
@@ -74,48 +74,48 @@ jobs:
       fail-fast: true
 
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions-rs/toolchain@v1
-      with:
-        toolchain: stable
-        target: x86_64-apple-darwin
-        default: true
-        override: true
-    - uses: Swatinem/rust-cache@v1
-    - uses: actions-rs/cargo@v1
-      with:
-        command: build
-        args: --release -p dijkstra_map_gd
-    - uses: actions/upload-artifact@v2
-      with:
-        name: libdijkstra_map_gd.dylib
-        path: target/release/libdijkstra_map_gd.dylib
+      - uses: actions/checkout@v3
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          target: x86_64-apple-darwin
+          default: true
+          override: true
+      - uses: Swatinem/rust-cache@v2
+      - uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --release -p dijkstra_map_gd
+      - uses: actions/upload-artifact@v3
+        with:
+          name: libdijkstra_map_gd.dylib
+          path: target/release/libdijkstra_map_gd.dylib
 
   commit:
     runs-on: ubuntu-latest
 
     needs: [build-linux, build-windows, build-macos]
-  
+
     steps:
-    - uses: actions/checkout@v2
-    - name: Download libdijkstra_map_gd.so
-      uses: actions/download-artifact@v2
-      with:
-        name: libdijkstra_map_gd.so
-        path: addons/dijkstra_map/Dijkstra_map_library/bin/linux/
-    - name: Download dijkstra_map_gd.dll
-      uses: actions/download-artifact@v2
-      with:
-        name: dijkstra_map_gd.dll
-        path: addons/dijkstra_map/Dijkstra_map_library/bin/windows/
-    - name: Download libdijkstra_map_gd.dylib
-      uses: actions/download-artifact@v2
-      with:
-        name: libdijkstra_map_gd.dylib
-        path: addons/dijkstra_map/Dijkstra_map_library/bin/macos/
-    - uses: stefanzweifel/git-auto-commit-action@v4
-      with:
-        commit_message: "Release ${{ github.event.inputs.version }}\n${{ github.event.inputs.body }}"
-    - uses: stefanzweifel/git-auto-commit-action@v4
-      with:
-        tagging_message: "${{ github.event.inputs.version }}\n${{ github.event.inputs.body }}"
+      - uses: actions/checkout@v3
+      - name: Download libdijkstra_map_gd.so
+        uses: actions/download-artifact@v3
+        with:
+          name: libdijkstra_map_gd.so
+          path: addons/dijkstra_map/Dijkstra_map_library/bin/linux/
+      - name: Download dijkstra_map_gd.dll
+        uses: actions/download-artifact@v3
+        with:
+          name: dijkstra_map_gd.dll
+          path: addons/dijkstra_map/Dijkstra_map_library/bin/windows/
+      - name: Download libdijkstra_map_gd.dylib
+        uses: actions/download-artifact@v3
+        with:
+          name: libdijkstra_map_gd.dylib
+          path: addons/dijkstra_map/Dijkstra_map_library/bin/macos/
+      - uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          commit_message: "Release ${{ github.event.inputs.version }}\n${{ github.event.inputs.body }}"
+      - uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          tagging_message: "${{ github.event.inputs.version }}\n${{ github.event.inputs.body }}"

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -12,18 +12,18 @@ env:
 jobs:
   test:
     name: test-${{ matrix.os }}
-    runs-on: ${{ matrix.os }}-latest
+    runs-on: ${{ matrix.os }}
 
     strategy:
       fail-fast: false
       matrix:
         include:
-          - os: ubuntu
+          - os: ubuntu-20.04
             target: x86_64-unknown-linux-gnu
           # windows doesn't work at the moment
           #- os: windows
           #  target: x86_64-pc-windows-msvc
-          - os: macos
+          - os: macos-latest
             target: x86_64-apple-darwin
 
     steps:

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -27,15 +27,15 @@ jobs:
             target: x86_64-apple-darwin
 
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions-rs/toolchain@v1
-      with:
-        toolchain: stable
-        target: ${{ matrix.target }}
-        default: true
-        override: true
-    - uses: Swatinem/rust-cache@v1
-    - uses: actions-rs/cargo@v1
-      with:
-        command: test
-        args: --verbose --workspace
+      - uses: actions/checkout@v3
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          target: ${{ matrix.target }}
+          default: true
+          override: true
+      - uses: Swatinem/rust-cache@v2
+      - uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --verbose --workspace

--- a/README.md
+++ b/README.md
@@ -17,6 +17,12 @@ Note that the [API](./addons/dijkstra-map/doc/index.md) is now stable! Some feat
 
 ## Installing
 
+Note: when installing pre-compiled libraries, we support
+
+- On linux: Ubuntu 20.04 or higher
+- On macos: The latest macOS version (11 at the time of writing)
+- On windows: Windows 10 or higher (presumably)
+
 ### Method 1: from the asset store (recommended)
 
 This will work for linux x64, macos x86 and windows x64 :


### PR DESCRIPTION
Update the github actions to
- Avoid deprecations
- only build the libraries via github actions, reject PRs that modify the libraries.
- Build and test the linux library on ubuntu 20.04. Hopefully this will resolve #114.

Note that this mean that all update to the shared libraries **must** go through github actions.
In particular, they all need a version number... Maybe this should be changed, or we should track this number somewhere, or we should always update the corresponding Godot asset library.