### PR TITLE
Removes the unsafe `get_connections_and_reverse` function

### DIFF
--- a/dijkstra-map/src/setters.rs
+++ b/dijkstra-map/src/setters.rs
@@ -143,41 +143,6 @@ impl DijkstraMap {
         }
     }
 
-    /// Return the connections of `source`, and the reverse connections of `target`.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`Err`] if `source` or `target` does not exist.
-    #[allow(clippy::type_complexity)]
-    fn get_connections_and_reverse(
-        &mut self,
-        source: PointId,
-        target: PointId,
-    ) -> Result<
-        (
-            &mut FnvHashMap<PointId, Weight>,
-            &mut FnvHashMap<PointId, Weight>,
-        ),
-        PointNotFound,
-    > {
-        /// Transmute limited to the lifetime.
-        ///
-        /// A bit safer than a raw `transmute`.
-        #[inline]
-        unsafe fn transmute_lifetime<'a, 'b, T>(e: &'a mut T) -> &'b mut T {
-            std::mem::transmute(e)
-        }
-
-        let PointInfo { connections, .. } = self.points.get_mut(&source).ok_or(PointNotFound)?;
-        // this is safe, because `connections` and `reverse_connections` are always disjoints, and we make no changes to `self.points`.
-        let connections: &'static mut _ = unsafe { transmute_lifetime(connections) };
-        let PointInfo {
-            reverse_connections,
-            ..
-        } = self.points.get_mut(&target).ok_or(PointNotFound)?;
-        Ok((connections, reverse_connections))
-    }
-
     /// Adds connection with given weight between a source point and target
     /// point.
     ///
@@ -187,7 +152,7 @@ impl DijkstraMap {
     /// - `target` : target point of the connection.
     /// - `weight` (default : `1.0`) : weight of the connection.
     /// - `bidirectional` (default : [`true`]) : wether or not the reciprocal
-    /// connection should be made.
+    ///   connection should be made.
     ///
     /// # Errors
     ///
@@ -205,9 +170,13 @@ impl DijkstraMap {
             self.connect_points(source, target, Some(weight), Some(false))
                 .and(self.connect_points(target, source, Some(weight), Some(false)))
         } else {
-            let (connections, reverse_connections) =
-                self.get_connections_and_reverse(source, target)?;
+            let PointInfo { connections, .. } =
+                self.points.get_mut(&source).ok_or(PointNotFound)?;
             connections.insert(target, weight);
+            let PointInfo {
+                reverse_connections,
+                ..
+            } = self.points.get_mut(&target).ok_or(PointNotFound)?;
             reverse_connections.insert(source, weight);
             Ok(())
         }
@@ -220,7 +189,7 @@ impl DijkstraMap {
     /// - `source` : source point of the connection.
     /// - `target` : target point of the connection.
     /// - `bidirectional` (default : [`true`]) : if [`true`], also removes the
-    /// connection from target to source.
+    ///   connection from target to source.
     ///
     /// # Errors
     ///
@@ -236,9 +205,13 @@ impl DijkstraMap {
             self.remove_connection(source, target, Some(false))
                 .and(self.remove_connection(target, source, Some(false)))
         } else {
-            let (connections, reverse_connections) =
-                self.get_connections_and_reverse(source, target)?;
+            let PointInfo { connections, .. } =
+                self.points.get_mut(&source).ok_or(PointNotFound)?;
             connections.remove(&target);
+            let PointInfo {
+                reverse_connections,
+                ..
+            } = self.points.get_mut(&target).ok_or(PointNotFound)?;
             reverse_connections.remove(&source);
             Ok(())
         }


### PR DESCRIPTION
This is something that I wanted to do for a long time. Also this function was probably unsound 😝 (maybe UB if `source == target`, because of some temporary mutable references)